### PR TITLE
Use config files for locked properties:

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = false
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[*.{yaml}]
+indent_size = 2

--- a/admin-pages-permissions.php
+++ b/admin-pages-permissions.php
@@ -153,21 +153,8 @@ class AdminPagesPermissionsPlugin extends Plugin
     public function checkLockedProps(Page $original, Page $new): Page
     {
         $filtered    = $new;
-        $lockedProps = [
-            'parent'   => [
-                'message'      => 'the parent',
-                'dependencies' => [
-                    'path',
-                    'route',
-                ],
-            ],
-            'template' => [
-                'message'      => 'the template',
-                'dependencies' => [
-                    'name',
-                ],
-            ],
-        ];
+
+        $lockedProps = $this->grav['config']["plugins.admin-pages-permissions"]['locked_props'];
 
         foreach ($lockedProps as $property => $value) {
             // If the property has been added, removed or changed…
@@ -200,7 +187,10 @@ class AdminPagesPermissionsPlugin extends Plugin
             $this->warnings++;
 
             $this->grav['messages']->add(
-                'You are not authorized to change ' . $value['message'] . '.',
+                $this->grav['language']->translate([
+                    'PLUGIN_ADMIN_PAGES_PERMISSIONS.WARNING_PROPERTY_LOCKED',
+                    $property
+                ]),
                 'warning'
             );
         }
@@ -220,14 +210,11 @@ class AdminPagesPermissionsPlugin extends Plugin
     public function checkLockedHeaderProps(object $original, object $new): object
     {
         $filtered = $new;
-        $lockedProps = [
-            'author'      => 'the author',
-            'permissions' => 'the permissions',
-            'sitemap'     => 'the Sitemap configuration',
-        ];
 
-        foreach ($lockedProps as $property => $value) {
-            // If the property has been added, removed or changed…
+        $lockedProps = $this->grav['config']["plugins.admin-pages-permissions"]['locked_header'];
+
+        foreach ($lockedProps as $property) {
+            // If the property has been added, removed or updated…
             $isAdded =
                 !property_exists($original, $property)
                 && property_exists($filtered, $property);
@@ -255,7 +242,10 @@ class AdminPagesPermissionsPlugin extends Plugin
             $this->warnings++;
 
             $this->grav['messages']->add(
-                'You are not authorized to change ' . $value . '.',
+                $this->grav['language']->translate([
+                    'PLUGIN_ADMIN_PAGES_PERMISSIONS.WARNING_PROPERTY_LOCKED',
+                    $property
+                ]),
                 'warning'
             );
         }
@@ -644,7 +634,9 @@ class AdminPagesPermissionsPlugin extends Plugin
         }
 
         $this->grav['messages']->add(
-            'You are not authorized to create a page in this parent page.',
+                $this->grav['language']->translate(
+                    'PLUGIN_ADMIN_PAGES_PERMISSIONS.WARNING_CREATE_IN_PARENT'
+                ),
             'error'
         );
 
@@ -702,7 +694,9 @@ class AdminPagesPermissionsPlugin extends Plugin
 
         if ($this->warnings > 0) {
             $this->grav['messages']->add(
-                'Changes with warnings have not been applied.',
+                $this->grav['language']->translate(
+                    'PLUGIN_ADMIN_PAGES_PERMISSIONS.WARNING_PROPERTY_REVERTED'
+                ),
                 'notice'
             );
         }
@@ -713,7 +707,9 @@ class AdminPagesPermissionsPlugin extends Plugin
         }
 
         $this->grav['messages']->add(
-            'You are not authorized to update this page.',
+            $this->grav['language']->translate(
+                'PLUGIN_ADMIN_PAGES_PERMISSIONS.WARNING_UPDATE'
+            ),
             'error'
         );
 

--- a/admin-pages-permissions.yaml
+++ b/admin-pages-permissions.yaml
@@ -8,3 +8,7 @@ permissions:
       update: true
       delete: true
       move: true
+locked_props: null
+locked_header:
+  - author
+  - permissions

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,4 +1,0 @@
-en:
-  PLUGIN_ADMIN_PAGES_PERMISSIONS:
-    TEXT_VARIABLE: Text Variable
-    TEXT_VARIABLE_HELP: Text to add to the top of a page

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,0 +1,9 @@
+PLUGIN_ADMIN_PAGES_PERMISSIONS:
+  WARNING_PROPERTY_LOCKED: |
+    You are not authorized to update the <strong>%1$s</strong> property.
+  WARNING_PROPERTY_REVERTED: |
+    Changes with warnings have not been applied.
+  WARNING_CREATE_IN_PARENT: |
+    You are not authorized to create a page in this parent page.
+  WARNING_UPDATE: |
+    You are not authorized to update this page.

--- a/languages/fr.yaml
+++ b/languages/fr.yaml
@@ -1,0 +1,9 @@
+PLUGIN_ADMIN_PAGES_PERMISSIONS:
+  WARNING_PROPERTY_LOCKED: |
+    Vous n’avez pas l’autorisation de modifier la propriété <strong>%1$s</strong>.
+  WARNING_PROPERTY_REVERTED: |
+    Les modifications avec un message d’erreur n’ont pas été appliquées
+  WARNING_CREATE_IN_PARENT: |
+    Vous n’avez pas l’autorisation de créer une page dans cette page parente.
+  WARNING_UPDATE: |
+    Vous n’avez pas l’autorisation de modifier cette page.


### PR DESCRIPTION
- Move hard-coded values to config.
- Document logic in Readme.
- Move hard‑coded strings to language files.
- Add more documentation in general.
- Add .editorconfig.